### PR TITLE
Change golang install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ HTTPLabs let you inspect HTTP requests and forge responses.
 # Install
 ### Golang
 ```bash
-go get github.com/gchaincl/httplab
-go install github.com/gchaincl/httplab/cmd/httplab
+go install github.com/gchaincl/httplab/cmd/httplab@latest
 ```
 
 ### Archlinux


### PR DESCRIPTION
With the latest version of golang there is no need to use `go get` to install a binary. 

With the current installation method there is an error returned:
```bash
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

I changed the command to reflect the go docuemntation